### PR TITLE
Fix duplicate destructuring and type conflicts

### DIFF
--- a/packages/tools/places/src/webSearch.ts
+++ b/packages/tools/places/src/webSearch.ts
@@ -214,7 +214,7 @@ export const WebSearchArgs = z.object({
 export const webSearch = new WebSearchTool();
 
 // Export the class as the main type
-export type { WebSearchTool };
+export type { WebSearchTool as WebSearchToolClass };
 
 async function executeWebSearch(
   params: z.infer<typeof WebSearchArgs>,
@@ -237,18 +237,9 @@ async function executeWebSearch(
     JSON.stringify(params, null, 2)
   );
 
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 15000);
-    try {
-      const {
-        query,
-        engine = 'google',
-        device = 'desktop',
-        google_domain = 'google.com',
-        hl = 'en',
-        gl = 'us',
-        num = 10,
-      } = args;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), 15000);
+  try {
 
       console.log('📋 Parsed arguments:');
       console.log('  - query:', query);
@@ -391,7 +382,7 @@ async function executeWebSearch(
   }
 
 // Legacy type for backward compatibility
-export type WebSearchTool = typeof webSearch;
+export type WebSearchToolInstance = typeof webSearch;
 
 export type WebSearchToolContext = {
   getSearchAPIKey: () => string;


### PR DESCRIPTION
## Description

This PR addresses two compilation issues within the `executeWebSearch` function and related types:

1.  **Duplicate Destructuring:** The `executeWebSearch` function was attempting to destructure its parameters twice, leading to "Cannot redeclare block-scoped variable" errors.
2.  **Type Naming Conflict:** There was a naming conflict between the `WebSearchTool` class type and a legacy `WebSearchTool` type export.

The changes resolve these issues by:
*   Removing the redundant second destructuring block in `executeWebSearch`.
*   Renaming the `WebSearchTool` class type to `WebSearchToolClass`.
*   Renaming the legacy `WebSearchTool` type to `WebSearchToolInstance`.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Performance improvement
- [ ] Refactoring (no functional changes)

## DCO Compliance

- [x] I have read the [Developer Certificate of Origin](https://developercertificate.org/)
- [x] All commits are signed with `Signed-off-by: Your Name <your.email@example.com>`
- [x] I understand that my contributions will be licensed under the same license as the project

## Additional Notes

None.

---
<a href="https://cursor.com/background-agent?bcId=bc-9f4746c5-946c-42de-b54e-942c82c61ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-9f4746c5-946c-42de-b54e-942c82c61ba2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

